### PR TITLE
Pillow and scipy added to the requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ cython
 numpy
 tensorflow-gpu==1.14.0
 tqdm
+scipy
+pillow


### PR DESCRIPTION
These packages are needed to run the scripts. After the merge of this PR it will be "automatically" installed with the `pip install -r requirements.txt` command