### PR TITLE
Enable parallel reading in from_files

### DIFF
--- a/libml/data.py
+++ b/libml/data.py
@@ -146,7 +146,7 @@ class DataSet:
                     sloppy=True))
         else:
             dataset = tf.data.TFRecordDataset(filenames)
-        return cls(tf.data.TFRecordDataset(filenames),
+        return cls(dataset,
                    augment_fn=augment_fn,
                    parse_fn=parse_fn,
                    image_shape=image_shape)


### PR DESCRIPTION
Hi, I noticed that the implementation of `from_files` in `libml.data` does not leverage the implementation of parallel reading currently. I fixed that.