### PR TITLE
Bump tensorflow-gpu from 1.14.0 to 2.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ absl-py
 easydict
 cython
 numpy
-tensorflow-gpu==1.14.0
+tensorflow-gpu==2.5.1
 tqdm
 scipy
 pillow


### PR DESCRIPTION
Forked from the development version of Fixmatch github from google-research:

Bumps [tensorflow-gpu](https://github.com/tensorflow/tensorflow) from 1.14.0 to 2.5.1.
- [Release notes](https://github.com/tensorflow/tensorflow/releases)
- [Changelog](https://github.com/tensorflow/tensorflow/blob/master/RELEASE.md)
- [Commits](https://github.com/tensorflow/tensorflow/compare/v1.14.0...v2.5.1)

---
updated-dependencies:
- dependency-name: tensorflow-gpu
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>